### PR TITLE
performance improved

### DIFF
--- a/cmd/zero/main.go
+++ b/cmd/zero/main.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"go/format"
+	"os"
+	"reflect"
+
+	"github.com/Code-Hex/dd"
+)
+
+func main() {
+	if err := run(context.Background()); err != nil {
+		fmt.Fprintf(os.Stderr, "err: %q", err.Error())
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context) error {
+	zeroPrimitives := []any{
+		false,
+		uint8(0),
+		uint16(0),
+		uint32(0),
+		uint64(0),
+		int8(0),
+		int16(0),
+		int32(0),
+		int64(0),
+		float32(0),
+		float64(0),
+		complex64(0),
+		complex128(0),
+		"",
+		int(0),
+		uint(0),
+		uintptr(0),
+	}
+	var buf bytes.Buffer
+	buf.WriteString("var zeroPrimitives = map[reflect.Type]string{\n")
+	for _, zero := range zeroPrimitives {
+		buf.WriteString("  ")
+		rt := reflect.TypeOf(zero)
+		fmt.Fprintf(&buf,
+			"reflect.TypeOf(%s(%#v)): %q,\n",
+			rt.String(), zero, dd.Dump(zero),
+		)
+	}
+	buf.WriteString("}\n")
+
+	src, err := format.Source(buf.Bytes())
+	if err != nil {
+		return err
+	}
+
+	f, err := os.Create("zero.go")
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	f.WriteString("package dd\n\n")
+	f.WriteString("import \"reflect\"\n\n")
+	_, err = f.Write(src)
+	return err
+}

--- a/complex_test.go
+++ b/complex_test.go
@@ -2,6 +2,7 @@ package dd_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"go/parser"
 	"io/ioutil"
 	"os"
@@ -17,29 +18,51 @@ import (
 
 var addressReplaceRegexp = regexp.MustCompile(`uintptr\((0x[\da-f]+)\)`)
 
-func TestComplex(t *testing.T) {
+type Entry struct {
+	name  string
+	value any
+	want  []byte
+}
+
+func makeEntries() ([]Entry, error) {
 	entries, err := os.ReadDir("testdata")
+	if err != nil {
+		return nil, fmt.Errorf("failed to read directory: %w", err)
+	}
+	ret := make([]Entry, len(entries))
+	for i, entry := range entries {
+		jsonFile := filepath.Join("testdata", entry.Name(), "data.json")
+		content, err := ioutil.ReadFile(jsonFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read file %q: %w", jsonFile, err)
+		}
+		wantFile := filepath.Join("testdata", entry.Name(), "want.txt")
+		want, err := ioutil.ReadFile(wantFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read file %q: %w", wantFile, err)
+		}
+		var unmarshaled any
+		if err := json.Unmarshal(content, &unmarshaled); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal: %w", err)
+		}
+		ret[i] = Entry{
+			name:  entry.Name(),
+			value: unmarshaled,
+			want:  want,
+		}
+	}
+	return ret, nil
+}
+
+func TestComplex(t *testing.T) {
+	entries, err := makeEntries()
 	if err != nil {
 		t.Fatal(err)
 	}
 	for _, entry := range entries {
-		t.Run(entry.Name(), func(t *testing.T) {
-			jsonFile := filepath.Join("testdata", entry.Name(), "data.json")
-			content, err := ioutil.ReadFile(jsonFile)
-			if err != nil {
-				t.Fatal(err)
-			}
-			wantFile := filepath.Join("testdata", entry.Name(), "want.txt")
-			want, err := ioutil.ReadFile(wantFile)
-			if err != nil {
-				t.Fatal(err)
-			}
-			var unmarshaled any
-			if err := json.Unmarshal(content, &unmarshaled); err != nil {
-				t.Fatal(err)
-			}
-
-			got := dd.Dump(unmarshaled)
+		entry := entry
+		t.Run(entry.name, func(t *testing.T) {
+			got := dd.Dump(entry.value)
 			// check syntax is valid
 			if _, err := parser.ParseExpr(got); err != nil {
 				t.Log(got)
@@ -47,11 +70,37 @@ func TestComplex(t *testing.T) {
 			}
 
 			// replace addresses
-			replacedWant := addressReplaceRegexp.ReplaceAll(want, []byte("0x0"))
+			replacedWant := addressReplaceRegexp.ReplaceAll(entry.want, []byte("0x0"))
 			replacedGot := addressReplaceRegexp.ReplaceAllString(got, "0x0")
 
 			if diff := cmp.Diff(string(replacedWant), replacedGot); diff != "" {
 				t.Fatalf("(-want, +got)\n%s", diff)
+			}
+		})
+	}
+}
+
+// 2022-03-20
+// goos: darwin
+// goarch: arm64
+// pkg: github.com/Code-Hex/dd
+// BenchmarkComplex/simple-8         	   34816	     32958 ns/op	   31119 B/op	     664 allocs/op
+// BenchmarkComplex/twitter-search-adaptive-8         	      19	  59854191 ns/op	68459998 B/op	  599905 allocs/op
+// PASS
+// ok  	github.com/Code-Hex/dd	3.076s
+
+func BenchmarkComplex(b *testing.B) {
+	entries, err := makeEntries()
+	if err != nil {
+		b.Fatal(err)
+	}
+	for _, entry := range entries {
+		entry := entry
+		b.Run(entry.name, func(b *testing.B) {
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				dd.Dump(entry.value)
 			}
 		})
 	}

--- a/complex_test.go
+++ b/complex_test.go
@@ -84,8 +84,8 @@ func TestComplex(t *testing.T) {
 // goos: darwin
 // goarch: arm64
 // pkg: github.com/Code-Hex/dd
-// BenchmarkComplex/simple-8         	   34816	     32958 ns/op	   31119 B/op	     664 allocs/op
-// BenchmarkComplex/twitter-search-adaptive-8         	      19	  59854191 ns/op	68459998 B/op	  599905 allocs/op
+// BenchmarkComplex/simple-8         	   45826	     25505 ns/op	   18303 B/op	     405 allocs/op
+// BenchmarkComplex/twitter-search-adaptive-8         	      25	  47194118 ns/op	45719134 B/op	  243727 allocs/op
 // PASS
 // ok  	github.com/Code-Hex/dd	3.076s
 

--- a/export.go
+++ b/export.go
@@ -15,7 +15,7 @@ const (
 
 // Dump dumps specified data.
 func Dump(data any, opts ...OptionFunc) string {
-	return newDataDumper(data, true, opts...).build().String()
+	return newDataDumper(data, opts...).build().String()
 }
 
 // Writer is a writer for dump string.

--- a/zero.go
+++ b/zero.go
@@ -1,0 +1,23 @@
+package dd
+
+import "reflect"
+
+var zeroPrimitives = map[reflect.Type]string{
+	reflect.TypeOf(bool(false)):          "false",
+	reflect.TypeOf(uint8(0x0)):           "0",
+	reflect.TypeOf(uint16(0x0)):          "0",
+	reflect.TypeOf(uint32(0x0)):          "0",
+	reflect.TypeOf(uint64(0x0)):          "0",
+	reflect.TypeOf(int8(0)):              "0",
+	reflect.TypeOf(int16(0)):             "0",
+	reflect.TypeOf(int32(0)):             "0",
+	reflect.TypeOf(int64(0)):             "0",
+	reflect.TypeOf(float32(0)):           "0.000000",
+	reflect.TypeOf(float64(0)):           "0.000000",
+	reflect.TypeOf(complex64((0 + 0i))):  "(0+0i)",
+	reflect.TypeOf(complex128((0 + 0i))): "(0+0i)",
+	reflect.TypeOf(string("")):           "\"\"",
+	reflect.TypeOf(int(0)):               "0",
+	reflect.TypeOf(uint(0x0)):            "0",
+	reflect.TypeOf(uintptr(0x0)):         "0",
+}


### PR DESCRIPTION
- added cached zero values
- added sync.Pool for dumper

prev

```
// goos: darwin
// goarch: arm64
// pkg: github.com/Code-Hex/dd
// BenchmarkComplex/simple-8         	   34816	     32958 ns/op	   31119 B/op	     664 allocs/op
// BenchmarkComplex/twitter-search-adaptive-8         	      19	  59854191 ns/op	68459998 B/op	  599905 allocs/op
// PASS
// ok  	github.com/Code-Hex/dd	3.076s
```

after

```
Running tool: /Users/codehex/sdk/go1.18/bin/go test -benchmem -run=^$ -bench ^BenchmarkComplex$ github.com/Code-Hex/dd

goos: darwin
goarch: arm64
pkg: github.com/Code-Hex/dd
BenchmarkComplex/simple-8         	   45826	     25505 ns/op	   18303 B/op	     405 allocs/op
BenchmarkComplex/twitter-search-adaptive-8         	      25	  47194118 ns/op	45719134 B/op	  243727 allocs/op
PASS
ok  	github.com/Code-Hex/dd	2.774s
```